### PR TITLE
Minor Editorial and Configation changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 Rust implementation of the Synchronizing Key Server for PGP keys.
 
 We will try to comply with the IETF Draft for [The OpenPGP HTTP Keyserver Protocol (HKP)](https://tools.ietf.org/html/draft-shaw-openpgp-hkp-00).
+**********************
+DEPRECATION of Gitlab repo:
+
+Effective Jan 1, 2018, ALL references to the gitlab will be phased out, as that repo has been deprecated, largely for better workflow and greater contributor intake here on Github.
+
+**********************
 
 ### CHANGELOG
 
@@ -31,6 +37,15 @@ Coming soon!
 It'll be helpful to have [Docker](https://www.docker.com/) installed.
 
 There is a [`docker-compose.yml`](docker-compose.yml) that can be loaded using either `docker stack` or `docker compose`. Run `docker stack deploy -c docker-compose.yml postgres` or `docker-compose up` depending on which tool you prefer to use. This will start [Postgres](https://www.postgresql.org://www.postgresql.org/) on port `5432`, as well as an [Adminer](https://www.adminer.org/) on port `8080`.
+
+Presently (Jan 2018) config.yml and docker-compose.yml use hard-coded user:password credentials, in real world deployment this should use some abstraction layer.  Examples of secure mechanisms for this would be docker_login or some external call to a AS in your infrastructure ((open)ldap,krb5,saml) that would be defined in an auth or environment variable. 
+
+As an example there is a stub file ( `auth_keys_from_cas` ) in this repo that could be used as a file that would have the hashed/encrypted values for tokens/user:pass entries for all auth'd users.
+
+	Example deployment using such a file: 
+	* 	User authenticates to local domain/AS server
+	*	Server passes (over secure channel communication (DTLS or other secure channel within organization's policies) to this file not much unlike a journal write of a auth attempt for admin/sudo rights. 
+	*	Config.yml calls this file to populate auth'd hosts/users and timeout periods of said tokens (if used), to populate it's auth'd user db or update it on some on-demand or periodic schedule.
 
 ### Known issues
 

--- a/auth_keys_from_cas
+++ b/auth_keys_from_cas
@@ -1,0 +1,8 @@
+# Variables for CAS Login 
+
+
+# TODO:
+# ----   
+# 1) Variable-ize passwordstore so as no passwords/creds are hardcoded.
+# 2) Define how github/gitlab/CAS-LDAP will all resolve to a endpoint for secure offloading.
+# 3) 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
         image: postgres
         restart: always
         environment:
-            POSTGRES_USER: sks
-            POSTGRES_PASSWORD: sks
+            POSTGRES_USER: auth_keys_from_cas/postgres
+            POSTGRES_PASSWORD: sauth_keys_from_cas/postgres
             POSTGRES_DB: sks
         ports:
             - 5432:5432

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -12,3 +12,22 @@ fn test_hello() {
     assert_eq!(response.status(), Status::Ok);
     assert_eq!(response.body_string(), Some("Hello, world!".into()));
 }
+
+#fn test_read_keydump() {
+    let app_server = server(rocket::ignite());
+    let client= Client::new(app_server).expect("valid rocket instance");
+#}
+#fn test_import_key_validate() {
+    let app_server = server(rocket::ignite());
+    let client= Client::new(app_server).expect("valid rocket instance");
+#}    
+#fn test_submit_key_validate() {
+    let app_server = server(rocket::ignite());
+    let client= Client::new(app_server).expect("valid rocket instance");
+#}
+#fn test_
+# TODO:
+# Setup a test keydump read from local 'dummy keydump'  and/or preset keydump from $(keyserver)
+# Setup a test import_key from user input of ASCII-armored data.
+# Setup a test read of both import and returned data from $(keyserver)
+ 

--- a/templates/index.html.tera
+++ b/templates/index.html.tera
@@ -26,10 +26,8 @@
                             </div>
                         </div>
                         <div class="text-center" style="margin-top: 0.5em;">
-                            <a data-toggle="collapse" data-target="#advancedOptionsCollapse" href="#">Advanced Options</a>
-                        </div>
-                        <div id="advancedOptionsCollapse" class="collapse">
-                            <div class="form-row">
+                          </div>
+                          <div class="form-row">
                                 <div class="col custom-controls-stacked ml-5 mt-3 mb-3">
                                     <label class="checkbox" for="fingerprint">
                                         <input type="checkbox" name="fingerprint" checked="checked" /> Show OpenPGP "fingerprints" for keys
@@ -63,14 +61,11 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="exampleModalLongTitle">Submit a PGP Key</h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                </div>
+                    </div>
                 <div class="modal-body">
                     <form action="/pks/add" method="post" id="keySubmitForm">
                         <div class="control-group">
-                            <label class="control-label" for="textarea">Enter an ASCII-armored OpenPGP key:</label>
+                            <label class="control-label" for="textarea">Enter your <strong> Public </strong>  ASCII-armored OpenPGP key:</label>
                             <div class="controls">
                                 <textarea id="textarea" name="keytext" rows="5" style="width: 100%;"></textarea>
                             </div>
@@ -78,7 +73,6 @@
                     </form>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">Close</button>
                     <button type="button" class="btn btn-outline-primary" onClick="submitHandler();">Submit Key</button>
                 </div>
             </div>


### PR DESCRIPTION
* Variable Config file extension for placeholder of deployment creds
* Added stub tests for keyserver, namely for read/submit validation
* Minor edits to reflect transposed edits from old gitlab repo (now deprecated)
* Added notes to README.md reflecting credentials use and hardening 
* Added Gitlab Deprecation notice to README.md